### PR TITLE
bugfix: add lxml requirements for KML pretty print

### DIFF
--- a/tour/traj-co/visualise.py
+++ b/tour/traj-co/visualise.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import lxml # required for pretty print for fastkml
 from fastkml import kml, styles
 from shapely.geometry import Point, LineString
 


### PR DESCRIPTION
Package lxml is necessary for pretty print to work in fastkml,
otherwise the generated KML file can not be rendered by Google maps.
